### PR TITLE
execute registerErrorHandler for init errorLevelMap field

### DIFF
--- a/src/MonologErrorHandler.php
+++ b/src/MonologErrorHandler.php
@@ -20,6 +20,9 @@ class MonologErrorHandler extends \CErrorHandler
         parent::init();
         $logger = Registry::getInstance($this->loggerName);
         $this->errorHandler = new ErrorHandler($logger);
+
+        $this->errorHandler->registerErrorHandler();
+        $this->errorHandler->registerExceptionHandler();
     }
 
     /**


### PR DESCRIPTION
Если этого не вызвать, то не работает маппинг уровней ошибок в методе handleError, все ошибки php логируются как critical в монологе.